### PR TITLE
Travis-CI will build and push only when GIT tag is created

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_deploy:
   # Set up git user name and tag this commit
   - git config --local user.email "travis@travis-ci.org"
   - git config --local user.name "Travis CI"
-  - git tag "$(date +'%Y.%m.%d-%H_%M')-$(git log --format=%h -1)"
+#  - git tag "$(date +'%Y.%m.%d-%H_%M')-$(git log --format=%h -1)"
 deploy:
   provider: releases
   api_key: $GITHUB_API_KEY
@@ -11,5 +11,5 @@ deploy:
   file: docs/target/*.zip
   skip_cleanup: true
   on:
-    tags: false
+    tags: true
     all_branches: true


### PR DESCRIPTION
Travis-CI will build artifacts and push them to github only when GIT tag is created.

Workflow:
1) git add ...
2) git tag "$(date +'%Y.%m.%d-%H_%M')-$(git log --format=%h -1)"
3) git push
4) git push --tags --> At this moment Travis-CI build will be triggered.